### PR TITLE
album search apiにreleasedを追加

### DIFF
--- a/app/views/api/albums/index.json.jbuilder
+++ b/app/views/api/albums/index.json.jbuilder
@@ -8,5 +8,6 @@ json.albums do
         json.partial! 'api/musics/music', music:
       end
     end
+    json.released album.released
   end
 end

--- a/app/views/api/musics/_music.json.jbuilder
+++ b/app/views/api/musics/_music.json.jbuilder
@@ -3,3 +3,4 @@ json.album music.album.name
 json.track music.track
 json.artist music.artist.name
 json.url album_music_url(music.album, music)
+json.released music.album.released

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -3,7 +3,6 @@ album1:
   kiki_taikai_date: 2022-01-01
   released: true
 
-
 album2:
   name: album2
   kiki_taikai_date: 2022-01-01

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,12 +1,15 @@
 album1:
   name: album1
   kiki_taikai_date: 2022-01-01
+  released: true
 
 
 album2:
   name: album2
   kiki_taikai_date: 2022-01-01
+  released: true
 
 album3:
   name: album3
   kiki_taikai_date: 2022-01-01
+  released: true

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -11,4 +11,4 @@ album2:
 album3:
   name: album3
   kiki_taikai_date: 2022-01-01
-  released: true
+  released: false

--- a/test/integration/api/albums_search_api_test.rb
+++ b/test/integration/api/albums_search_api_test.rb
@@ -27,5 +27,6 @@ class Api::AlbumsSearchApiTest < ActionDispatch::IntegrationTest
     assert_equal @album.name, res['albums'][0]['name']
     assert_equal @album.kiki_taikai_date.strftime('%Y-%m-%d'), res['albums'][0]['kiki_taikai_date']
     assert_equal album_url(@album), res['albums'][0]['url']
+    assert_equal @album.released, res['albums'][0]['released']
   end
 end

--- a/test/integration/api/musics_search_api_test.rb
+++ b/test/integration/api/musics_search_api_test.rb
@@ -26,7 +26,7 @@ class Api::MusicsSearchApiTest < ActionDispatch::IntegrationTest
     res = JSON.parse(response.body)
     expected_response = [{ 'name' => @music.name, 'album' => @music.album.name, 'track' => @music.track,
                            'artist' => @music.artist.name, 'url' => album_music_url(@music.album, @music),
-                          'released' => @music.album.released}]
+                           'released' => @music.album.released }]
     assert_equal expected_response, res['musics']
   end
 end

--- a/test/integration/api/musics_search_api_test.rb
+++ b/test/integration/api/musics_search_api_test.rb
@@ -25,7 +25,8 @@ class Api::MusicsSearchApiTest < ActionDispatch::IntegrationTest
     assert_response 200
     res = JSON.parse(response.body)
     expected_response = [{ 'name' => @music.name, 'album' => @music.album.name, 'track' => @music.track,
-                           'artist' => @music.artist.name, 'url' => album_music_url(@music.album, @music) }]
+                           'artist' => @music.artist.name, 'url' => album_music_url(@music.album, @music),
+                          'released' => @music.album.released}]
     assert_equal expected_response, res['musics']
   end
 end

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -39,4 +39,8 @@ class AlbumTest < ActiveSupport::TestCase
       assert_not @album.valid?, "#{date.inspect} should be invalid"
     end
   end
+
+  test 'jacketが正常にattachされる' do
+    assert @album.jacket.attached?
+  end
 end


### PR DESCRIPTION
fix: #160 
こんな感じになりました。ついでにmusic search apiにもreleasedを追加しました。
![スクリーンショット 2023-03-03 122159](https://user-images.githubusercontent.com/104709001/222715424-f9291d88-ef07-4450-8d49-80b18a85db6b.png)
![スクリーンショット 2023-03-03 122250](https://user-images.githubusercontent.com/104709001/222715473-9c777f75-22ba-45a7-a8fc-a4f39adb77dc.png)
![スクリーンショット 2023-03-03 122159](https://user-images.githubusercontent.com/104709001/222715485-cd05f2d2-1ed7-4661-91b6-f982bc266411.png)

副作用としてテストが通らなくなっちゃった（おかしかったのが顕在化した）#161