### PR TITLE
インデックス情報登録フォーム聴き大会から二週間の間、トップページにインデックス情報登録フォームへ飛べるバナーを表示する

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -6,5 +6,6 @@ class StaticPagesController < ApplicationController
     @comments = Comment.limit(10).includes([music: :artist], :user,
                                            [album: [jacket_attachment: [blob: :variant_records]]])
     @playlists = Playlist.where(public: true).includes(:user)[0..9]
+    @albums_opening_form = Album.where(kiki_taikai_date: Time.zone.today.ago(14.days)..)
   end
 end

--- a/app/views/albums/show.html.haml
+++ b/app/views/albums/show.html.haml
@@ -27,6 +27,7 @@
         = @total_length%60
         秒
       =link_to "ツイッターで共有", "https://twitter.com/share?url=#{album_url(@album)}&text=#{@album.name}", target: "blank", class: 'btn btn-primary mb-3 btn-sm'
+      =link_to "form", new_album_music_path(@album), class: 'btn btn-primary mb-3 btn-sm'
    
 .container-fluid.mb-4.h-auto.overflow-hidden
   -if current_user.editor?

--- a/app/views/static_pages/home.html.haml
+++ b/app/views/static_pages/home.html.haml
@@ -1,10 +1,24 @@
 -provide(:title, 'Home')
 - if DaikichiForm.where(form_closed: false).present?
-  = link_to daikichi_forms_path do
-    = image_tag 'daikichi_vote_banner.gif', width: "500px"
-  = link_to daikichi_forms_path do
-    = image_tag 'daikichi_vote_banner.gif', width: "500px", class: 'wide-inline-block'
-%h1 最新リリース
+  .daikichi_form_banner
+    = link_to daikichi_forms_path do
+      = image_tag 'daikichi_vote_banner.gif', width: "500px"
+    = link_to daikichi_forms_path do
+      = image_tag 'daikichi_vote_banner.gif', width: "500px", class: 'wide-inline-block'
+- if @albums_opening_form
+  .album_form_banner
+    %h1 インデックス情報登録フォーム
+    %table.table.align-middle.table-striped
+      %thead
+        %tr
+          %th アルバム
+          %th 締め切り
+      %tbody
+        - @albums_opening_form.each do |album| 
+          %tr
+            %td= link_to album.name, new_album_music_path(album)
+            %td= album.kiki_taikai_date.days_since(14)
+%h1.mt-3 最新リリース
 .album-container.border-bottom.pb-2.border-2
   - @albums_released.each do |album|
     = link_to album_path(album), class: "album-background" do

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -3,12 +3,24 @@ require 'test_helper'
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
   def setup
     @admin_user = users(:admin_user)
+    @album = albums(:album1)
+    log_in_as(@admin_user)
   end
 
   test 'ホーム描写' do
-    log_in_as(@admin_user)
     get root_path
     assert_response :success
     assert_select 'title', 'Kitchotify - Home'
+  end
+
+  test 'インデックス情報登録フォームのバナーが適切に表示される' do
+    patch album_path(@album), params: { album: { kiki_taikai_date: Time.zone.today.ago(15.days) } }
+    @album.reload
+    get root_path
+    assert_select 'a[href=?]', new_album_music_path(@album), count: 0
+    patch album_path(@album), params: { album: { kiki_taikai_date: Time.zone.today.ago(14.days) } }
+    @album.reload
+    get root_path
+    assert_select 'a[href=?]', new_album_music_path(@album), @album.name
   end
 end


### PR DESCRIPTION
fix: #225